### PR TITLE
feat: support basic context menu

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,7 +2,7 @@ import { WebBrowserView } from "./web_browser_view";
 
 // TODO: Change this whole thing to use https://github.com/pjeby/monkey-around instead.
 export class FunctionHooks {
-    private static ogWindow$Open: (url?: string | URL, target?: string, features?: string) => WindowProxy | null;
+    static ogWindow$Open: (url?: string | URL, target?: string, features?: string) => WindowProxy | null;
 
     static onload() {
         FunctionHooks.ogWindow$Open = window.open;

--- a/src/web_browser_view.ts
+++ b/src/web_browser_view.ts
@@ -13,8 +13,6 @@ export class WebBrowserView extends ItemView {
     private favicon: HTMLImageElement;
     private frame: HTMLIFrameElement;
 
-	onDom: any;
-
     static spawnWebBrowserView(newLeaf: boolean, state: WebBrowserViewState) {
         app.workspace.getLeaf(newLeaf).setViewState({ type: WEB_BROWSER_VIEW_ID, active: true, state });
     }
@@ -64,8 +62,6 @@ export class WebBrowserView extends ItemView {
 
 			const { Menu, MenuItem } = remote;
 			webContents.on("context-menu", (event: any, params: any) => {
-				    // Should add whitelist for some websites that have their own context menu.
-				    // Maybe notion? word?
 					event.preventDefault();
 
 					const menu = new Menu();


### PR DESCRIPTION
resolved: #39 

In this pr:

webview context menu support three main (basic) features:
- Open current URL in external browser
- Copy Text
- Copy Highlight link (based on text-fragment from chrome features? chromium features)

And I did try to use Obsidian default context menu api, I found it is diffcult to handle the context menu life cycle because when we click on the iframe in the webview, obsidian didn't react to it.

And there are still some features / command to be added into the context menu. 

---

```
var urlRegEx2 = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)/g;
```

is used for detect url like : `https://github.com/Trikzon/obsidian-web-browser/compare/main...Quorafind:obsidian-web-browser:feature/webview-context-menu?expand=1#diff-62273fc3fd92e90a0259fd41071a9a4114ec24773a46aff160f748c2376128faR209`